### PR TITLE
Normals should be transformed to camera-space.

### DIFF
--- a/pyrender/shaders/mesh.vert
+++ b/pyrender/shaders/mesh.vert
@@ -58,7 +58,7 @@ void main()
     gl_Position = P * V * M * inst_m * vec4(position, 1);
     frag_position = vec3(M * inst_m * vec4(position, 1.0));
 
-    mat4 N = transpose(inverse(M * inst_m));
+    mat4 N = transpose(inverse(V * M * inst_m));
 
 #ifdef NORMAL_LOC
     frag_normal = normalize(vec3(N * vec4(normal, 0.0)));


### PR DESCRIPTION
This fixes the normals being incorrect when the camera is moved instead
of the scene.