### PR TITLE
Add ALL_CAM_COORDS flag to render camera coordinates.

### DIFF
--- a/pyrender/constants.py
+++ b/pyrender/constants.py
@@ -10,6 +10,12 @@ SHADOW_TEX_SZ = 1024      # Width and Height of Shadow Textures
 TEXT_PADDING = 20         # Width of padding for rendering text (px)
 
 
+def _flag_value(i):
+    if i == 0:
+        return 0
+    return 2 ** (i - 1)
+
+
 # Flags for render type
 class RenderFlags(object):
     """Flags for rendering in the scene.
@@ -21,34 +27,40 @@ class RenderFlags(object):
     would result in an offscreen render with directional shadows and
     vertex normals enabled.
     """
-    NONE = 0
+    NONE = _flag_value(0)
     """Normal PBR Render."""
-    DEPTH_ONLY = 1
+    NO_LIGHTS = _flag_value(1)
+    """Do not render lights."""
+    NO_MATERIALS = _flag_value(2)
+    """Do not render lights."""
+    DEPTH_ONLY = NO_LIGHTS | NO_MATERIALS | _flag_value(3)
     """Only render the depth buffer."""
-    OFFSCREEN = 2
+    OFFSCREEN = _flag_value(4)
     """Render offscreen and return the depth and (optionally) color buffers."""
-    FLIP_WIREFRAME = 4
+    FLIP_WIREFRAME = _flag_value(5)
     """Invert the status of wireframe rendering for each mesh."""
-    ALL_WIREFRAME = 8
+    ALL_WIREFRAME = _flag_value(6)
     """Render all meshes as wireframes."""
-    ALL_SOLID = 16
+    ALL_SOLID = _flag_value(7)
     """Render all meshes as solids."""
-    SHADOWS_DIRECTIONAL = 32
+    SHADOWS_DIRECTIONAL = _flag_value(8)
     """Render shadows for directional lights."""
-    SHADOWS_POINT = 64
+    SHADOWS_POINT = _flag_value(9)
     """Render shadows for point lights."""
-    SHADOWS_SPOT = 128
+    SHADOWS_SPOT = _flag_value(10)
     """Render shadows for spot lights."""
-    SHADOWS_ALL = 32 | 64 | 128
+    SHADOWS_ALL = SHADOWS_DIRECTIONAL | SHADOWS_POINT | SHADOWS_SPOT
     """Render shadows for all lights."""
-    VERTEX_NORMALS = 256
+    VERTEX_NORMALS = _flag_value(11)
     """Render vertex normals."""
-    FACE_NORMALS = 512
+    FACE_NORMALS = _flag_value(12)
     """Render face normals."""
-    SKIP_CULL_FACES = 1024
+    SKIP_CULL_FACES = _flag_value(13)
     """Do not cull back faces."""
-    RGBA = 2048
+    RGBA = _flag_value(14)
     """Render the color buffer with the alpha channel enabled."""
+    ALL_CAM_COORDS = NO_LIGHTS | NO_MATERIALS | _flag_value(15)
+    """Render the camera coordinates of pixels."""
 
 
 class TextAlign:

--- a/pyrender/renderer.py
+++ b/pyrender/renderer.py
@@ -354,7 +354,7 @@ class Renderer(object):
                 )
 
                 # Next, bind the lighting
-                if not flags & RenderFlags.DEPTH_ONLY:
+                if not flags & RenderFlags.NO_LIGHTS:
                     self._bind_lighting(scene, program, node, flags)
 
                 # Finally, bind and draw the primitive
@@ -488,7 +488,7 @@ class Renderer(object):
         primitive._bind()
 
         # Bind mesh material
-        if not flags & RenderFlags.DEPTH_ONLY:
+        if not flags & RenderFlags.NO_MATERIALS:
             material = primitive.material
 
             # Bind textures
@@ -870,8 +870,11 @@ class Renderer(object):
         geometry_shader = None
         defines = {}
 
-        if (bool(program_flags & ProgramFlags.USE_MATERIAL) and
-                not flags & RenderFlags.DEPTH_ONLY):
+        if bool(flags & RenderFlags.ALL_CAM_COORDS):
+            vertex_shader = 'mesh_coords.vert'
+            fragment_shader = 'mesh_coords.frag'
+        elif (bool(program_flags & ProgramFlags.USE_MATERIAL) and
+                not flags & RenderFlags.NO_MATERIALS):
             vertex_shader = 'mesh.vert'
             fragment_shader = 'mesh.frag'
         elif bool(program_flags & (ProgramFlags.VERTEX_NORMALS |
@@ -1197,7 +1200,7 @@ class Renderer(object):
                 )
 
                 # Next, bind the lighting
-                if not flags & RenderFlags.DEPTH_ONLY:
+                if not flags & RenderFlags.NO_LIGHTS:
                     self._bind_lighting(scene, program, node, flags)
 
                 # Finally, bind and draw the primitive

--- a/pyrender/shaders/mesh_coords.frag
+++ b/pyrender/shaders/mesh_coords.frag
@@ -1,0 +1,10 @@
+#version 330 core
+
+out vec4 frag_color;
+
+in vec3 frag_position_cam;
+
+void main()
+{
+    frag_color = vec4(frag_position_cam, 1.0);
+}

--- a/pyrender/shaders/mesh_coords.vert
+++ b/pyrender/shaders/mesh_coords.vert
@@ -1,0 +1,20 @@
+#version 330 core
+
+// Inputs
+layout(location = 0) in vec3 position;
+layout(location = NORMAL_LOC) in vec3 normal;
+layout(location = INST_M_LOC) in mat4 inst_m;
+
+// Output data
+out vec3 frag_position_cam;
+
+// Uniform data
+uniform mat4 M;
+uniform mat4 V;
+uniform mat4 P;
+
+// Render loop
+void main() {
+    frag_position_cam = vec3(V * M * inst_m * vec4(position, 1.0));
+    gl_Position = P * V * M * inst_m * vec4(position, 1);
+}

--- a/pyrender/viewer.py
+++ b/pyrender/viewer.py
@@ -983,6 +983,8 @@ class Viewer(pyglet.window.Window):
             flags |= RenderFlags.FACE_NORMALS
         if not self.render_flags['cull_faces']:
             flags |= RenderFlags.SKIP_CULL_FACES
+        if self.render_flags['all_camera_coords']:
+            flags |= RenderFlags.ALL_CAM_COORDS
 
         self._renderer.render(self.scene, flags)
 


### PR DESCRIPTION
- Defines NO_LIGHTS and NO_MATERIALS which are subsets of DEPTH_ONLY.
- Replace DEPTH_ONLY with NO_LIGHTS and NO_MATERIALS in places.
- Add ALL_CAM_COORDS.

This cam be easily extended to render other things such as per-pixel
normals etc. or world-space coordinates.

It would be nice to have a more general way to just pass in a custom
shader but this was the easiest to do for now.