### PR TITLE
Add pyrender.platforms package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'Topic :: Scientific/Engineering'
     ],
     keywords = 'rendering graphics opengl 3d visualization pbr gltf',
-    packages = ['pyrender'],
+    packages = ['pyrender', 'pyrender.platforms'],
     setup_requires = requirements,
     install_requires = requirements,
     extras_require={


### PR DESCRIPTION
This was missing, causing examples/example.py to crash.