### PR TITLE
Fix reordering of lights by distance in _bind_lighting

### DIFF
--- a/pyrender/constants.py
+++ b/pyrender/constants.py
@@ -1,7 +1,7 @@
 DEFAULT_Z_NEAR = 0.05     # Near clipping plane, in meters
 DEFAULT_Z_FAR = 100.0     # Far clipping plane, in meters
 DEFAULT_SCENE_SCALE = 2.0 # Default scene scale
-MAX_N_LIGHTS = 4          # Maximum number of lights of each type allowed
+MAX_N_LIGHTS = 8          # Maximum number of lights of each type allowed
 OPEN_GL_MAJOR = 4         # Target OpenGL Major Version
 OPEN_GL_MINOR = 1         # Target OpenGL Minor Version
 FLOAT_SZ = 4              # Byte size of GL float32

--- a/pyrender/renderer.py
+++ b/pyrender/renderer.py
@@ -636,8 +636,8 @@ class Renderer(object):
 
         light_nodes = scene.light_nodes
         if (len(scene.directional_light_nodes) > max_n_lights[0] or
-            len(scene.spot_light_nodes) > max_n_lights[1] or
-            len(scene.point_light_nodes) > max_n_lights[2]):
+                len(scene.spot_light_nodes) > max_n_lights[1] or
+                len(scene.point_light_nodes) > max_n_lights[2]):
             light_nodes = self._sorted_nodes_by_distance(
                 scene, scene.light_nodes, node
             )
@@ -718,7 +718,7 @@ class Renderer(object):
     def _sorted_nodes_by_distance(self, scene, nodes, compare_node):
         nodes = list(nodes)
         compare_posn = scene.get_pose(compare_node)[:3,3]
-        nodes.sort(key=lambda n: -np.linalg.norm(
+        nodes.sort(key=lambda n: np.linalg.norm(
             scene.get_pose(n)[:3,3] - compare_posn)
         )
         return nodes

--- a/pyrender/renderer.py
+++ b/pyrender/renderer.py
@@ -635,8 +635,9 @@ class Renderer(object):
         dlc = 0
 
         light_nodes = scene.light_nodes
-        if (n_d > max_n_lights[0] or n_s > max_n_lights[1] or
-                n_p > max_n_lights[2]):
+        if (len(scene.directional_light_nodes) > max_n_lights[0] or
+            len(scene.spot_light_nodes) > max_n_lights[1] or
+            len(scene.point_light_nodes) > max_n_lights[2]):
             light_nodes = self._sorted_nodes_by_distance(
                 scene, scene.light_nodes, node
             )

--- a/pyrender/renderer.py
+++ b/pyrender/renderer.py
@@ -9,7 +9,7 @@ import PIL
 
 from .constants import (RenderFlags, TextAlign, GLTF, BufFlags, TexFlags,
                         ProgramFlags, DEFAULT_Z_FAR, DEFAULT_Z_NEAR,
-                        SHADOW_TEX_SZ)
+                        SHADOW_TEX_SZ, MAX_N_LIGHTS)
 from .shader_program import ShaderProgramCache
 from .material import MetallicRoughnessMaterial, SpecularGlossinessMaterial
 from .light import PointLight, SpotLight, DirectionalLight
@@ -853,7 +853,7 @@ class Renderer(object):
         return program
 
     def _compute_max_n_lights(self, flags):
-        max_n_lights = [8, 8, 8]
+        max_n_lights = [MAX_N_LIGHTS, MAX_N_LIGHTS, MAX_N_LIGHTS]
         n_tex_units = glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS)
 
         # Reserved texture units: 6


### PR DESCRIPTION
reordering of lights in `_bind_lighting` is not hit when needed, or ever:

```
n_d > max_n_lights[0] or n_s > max_n_lights[1] or n_p > max_n_lights[2]
```
is always false if:

```
 n_d = min(len(scene.directional_light_nodes), max_n_lights[0])
 n_s = min(len(scene.spot_light_nodes), max_n_lights[1])
 n_p = min(len(scene.point_light_nodes), max_n_lights[2])
```

Fixes:
* above
* `MAX_N_LIGHTS` can be used in this function, and needs to be set to 8
* Order lights from the closest instead of from the furthest 