### PR TITLE
Windows compatible xlib wrapping

### DIFF
--- a/pyrender/platforms/pyglet_platform.py
+++ b/pyrender/platforms/pyglet_platform.py
@@ -50,8 +50,11 @@ class PygletPlatform(Platform):
             self._window.switch_to()
 
     def make_uncurrent(self):
-        import pyglet
-        pyglet.gl.xlib.glx.glXMakeContextCurrent(self._window.context.x_display, 0, 0, None)
+        try:
+            import pyglet
+            pyglet.gl.xlib.glx.glXMakeContextCurrent(self._window.context.x_display, 0, 0, None)
+        except Exception:
+            pass
 
     def delete_context(self):
         if self._window is not None:


### PR DESCRIPTION
As in other parts of this very source file, the xlib commands are wrapped in a try/except.
This addresses issues like https://github.com/mmatl/pyrender/issues/117