### PR TITLE
use wgl on Windows

### DIFF
--- a/pyrender/platforms/pyglet_platform.py
+++ b/pyrender/platforms/pyglet_platform.py
@@ -51,7 +51,10 @@ class PygletPlatform(Platform):
 
     def make_uncurrent(self):
         import pyglet
-        pyglet.gl.xlib.glx.glXMakeContextCurrent(self._window.context.x_display, 0, 0, None)
+        if hasattr(pyglet.gl, 'xlib'):
+            pyglet.gl.xlib.glx.glXMakeContextCurrent(self._window.context.x_display, 0, 0, None)
+        elif hasattr(pyglet.gl, 'wgl'):
+            pyglet.gl.wgl.wglMakeCurrent(self._window.canvas.hdc, None)
 
     def delete_context(self):
         if self._window is not None:


### PR DESCRIPTION
Offscreen rendering fails on Windows:

  File "C:\Users\GuillaumeDev\anaconda3\envs\yokai\lib\site-packages\pyrender\offscreen.py", line 113, in render
    self._platform.make_uncurrent()
  File "C:\Users\GuillaumeDev\anaconda3\envs\yokai\lib\site-packages\pyrender\platforms\pyglet_platform.py", line 54, in make_uncurrent
    pyglet.gl.xlib.glx.glXMakeContextCurrent(self._window.context.x_display, 0, 0, None)
AttributeError: module 'pyglet.gl' has no attribute 'xlib'

This PR use xlib if it actually exists and may fallback to wgl if found.