### PR TITLE
Made PyOpenGL version flexible at setup.py to avoid OSMesa rendering issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ requirements = [
     'numpy',                      # Numpy
     'Pillow',                     # For Trimesh texture conversions
     'pyglet>=1.4.10',             # For the pyglet viewer
-    'PyOpenGL==3.1.0',            # For OpenGL
-#    'PyOpenGL_accelerate==3.1.0', # For OpenGL
+    'PyOpenGL~=3.1.0',            # For OpenGL
+#    'PyOpenGL_accelerate~=3.1.0', # For OpenGL
     'scipy',                      # Because of trimesh missing dep
     'six',                        # For Python 2/3 interop
     'trimesh',                    # For meshes


### PR DESCRIPTION
Related to this issue:
https://github.com/mmatl/pyrender/issues/13

I was experiencing the same issue with `pyrender==0.1.45` and `PyOpenGL==3.1.0`. Then upgraded to `PyOpenGL==3.1.5` (and `PyOpenGL-accelerate==3.1.5`) and the problem was solved.

So I would kindly suggest at least making this PyOpenGL version flexible at the pyrender setup.py in order to be able to install different versions of PyOpenGL when stricly needed, as it would be the case. Otherwise I would not be able to have a requirements.txt with both `pyrender==0.1.45` and `PyOpenGL==3.1.5` because they are not compatible at the point of installation (setup.py).

Many thanks for your time.