### PR TITLE
Add option to use flat lighting in pyrender.Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The available keyboard commands are as follows:
 * `c`: Toggles backface culling.
 * `f`: Toggles fullscreen mode.
 * `h`: Toggles shadow rendering.
-* `i`: Toggles axis display mode (no axes, world axis, mesh axes, all axes).
-* `l`: Toggles lighting mode (scene lighting, Raymond lighting, or direct lighting).
+* `i`: Cycles axis display mode (no axes, world axis, mesh axes, all axes).
+* `l`: Cycles lighting mode (scene lighting, Raymond lighting, or direct lighting).
 * `L`: Uses flat lighting mode.
 * `m`: Toggles face normal visualization.
 * `n`: Toggles vertex normal visualization.
@@ -85,7 +85,7 @@ The available keyboard commands are as follows:
 * `q`: Quits the viewer.
 * `r`: Starts recording a GIF, and pressing again stops recording and opens a file dialog.
 * `s`: Opens a file dialog to save the current view as an image.
-* `w`: Toggles wireframe mode (scene default, flip wireframes, all wireframe, or all solid).
+* `w`: Cycles wireframe mode (scene default, flip wireframes, all wireframe, or all solid).
 * `z`: Resets the camera to the default view.
 
 As a note, displaying shadows significantly slows down rendering, so if you're

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The available keyboard commands are as follows:
 * `h`: Toggles shadow rendering.
 * `i`: Toggles axis display mode (no axes, world axis, mesh axes, all axes).
 * `l`: Toggles lighting mode (scene lighting, Raymond lighting, or direct lighting).
+* `L`: Uses flat lighting mode.
 * `m`: Toggles face normal visualization.
 * `n`: Toggles vertex normal visualization.
 * `o`: Toggles orthographic camera mode.

--- a/pyrender/viewer.py
+++ b/pyrender/viewer.py
@@ -96,6 +96,7 @@ class Viewer(pyglet.window.Window):
       (no axes, world axis, mesh axes, all axes).
     - ``l``: Toggles lighting mode
       (scene lighting, Raymond lighting, or direct lighting).
+    - ``L``: Uses flat lighting mode.
     - ``m``: Toggles face normal visualization.
     - ``n``: Toggles vertex normal visualization.
     - ``o``: Toggles orthographic mode.
@@ -751,7 +752,23 @@ class Viewer(pyglet.window.Window):
 
         # L toggles the lighting mode
         elif symbol == pyglet.window.key.L:
-            if self.viewer_flags['use_raymond_lighting']:
+            # SHIFT+L sets flat lighting
+            if modifiers & pyglet.window.key.MOD_SHIFT:
+                self.render_flags['flat'] = True
+                self._message_text = 'Flat Lighting'
+
+            # L unsets flat lighting if set
+            elif self.render_flags['flat']:
+                self.render_flags['flat'] = False
+                if self.viewer_flags['use_raymond_lighting']:
+                    self._message_text = 'Raymond Lighting'
+                elif self.viewer_flags['use_direct_lighting']:
+                    self._message_text = 'Direct Lighting'
+                else:
+                    self._message_text = 'Default Lighting'
+
+            # otherwise cycles lighting mode
+            elif self.viewer_flags['use_raymond_lighting']:
                 self.viewer_flags['use_raymond_lighting'] = False
                 self.viewer_flags['use_direct_lighting'] = True
                 self._message_text = 'Direct Lighting'

--- a/pyrender/viewer.py
+++ b/pyrender/viewer.py
@@ -126,6 +126,8 @@ class Viewer(pyglet.window.Window):
       blue lines. Defaults to `False`.
     - ``cull_faces``: `bool`, If `True`, backfaces will be culled.
       Defaults to `True`.
+    - ``flat``: `bool`, If `True`, render the color buffer flat,
+      with no lighting computations. Defaults to `True`.
     - ``point_size`` : float, The point size in pixels. Defaults to 1px.
 
     Note
@@ -198,6 +200,7 @@ class Viewer(pyglet.window.Window):
             'face_normals': False,
             'cull_faces': True,
             'point_size': 1.0,
+            'flat': False,
         }
         self._default_viewer_flags = {
             'mouse_pressed': False,
@@ -985,6 +988,8 @@ class Viewer(pyglet.window.Window):
             flags |= RenderFlags.FACE_NORMALS
         if not self.render_flags['cull_faces']:
             flags |= RenderFlags.SKIP_CULL_FACES
+        if self.render_flags['flat']:
+            flags |= RenderFlags.FLAT
 
         self._renderer.render(self.scene, flags)
 

--- a/pyrender/viewer.py
+++ b/pyrender/viewer.py
@@ -92,9 +92,9 @@ class Viewer(pyglet.window.Window):
     - ``c``: Toggles backface culling.
     - ``f``: Toggles fullscreen mode.
     - ``h``: Toggles shadow rendering.
-    - ``i``: Toggles axis display mode
+    - ``i``: Cycles axis display mode
       (no axes, world axis, mesh axes, all axes).
-    - ``l``: Toggles lighting mode
+    - ``l``: Cycles lighting mode
       (scene lighting, Raymond lighting, or direct lighting).
     - ``L``: Uses flat lighting mode.
     - ``m``: Toggles face normal visualization.
@@ -104,7 +104,7 @@ class Viewer(pyglet.window.Window):
     - ``r``: Starts recording a GIF, and pressing again stops recording
       and opens a file dialog.
     - ``s``: Opens a file dialog to save the current view as an image.
-    - ``w``: Toggles wireframe mode
+    - ``w``: Cycles wireframe mode
       (scene default, flip wireframes, all wireframe, or all solid).
     - ``z``: Resets the camera to the initial view.
 
@@ -750,7 +750,7 @@ class Viewer(pyglet.window.Window):
                 self._set_axes(True, False)
                 self._message_text = 'World Axis On'
 
-        # L toggles the lighting mode
+        # L cycles the lighting mode
         elif symbol == pyglet.window.key.L:
             # SHIFT+L sets flat lighting
             if modifiers & pyglet.window.key.MOD_SHIFT:


### PR DESCRIPTION
- Add `flat` kwarg to pyrender.Viewer.
- Add keybind to toggle it (`SHIFT+L`).
- Reword some documentation from "Toggles" to "Cycles" when concerned with more that two states.

Tested working in my environment.

fixes #51