### PR TITLE
zfar defaults to DEFAULT_Z_FAR in PerspectiveCamera

### DIFF
--- a/pyrender/camera.py
+++ b/pyrender/camera.py
@@ -117,7 +117,7 @@ class PerspectiveCamera(Camera):
     def __init__(self,
                  yfov,
                  znear=DEFAULT_Z_NEAR,
-                 zfar=None,
+                 zfar=DEFAULT_Z_FAR,
                  aspectRatio=None,
                  name=None):
         super(PerspectiveCamera, self).__init__(


### PR DESCRIPTION
added default argument `zfar=DEFAULT_Z_FAR` to PerspectiveCamera to match the other camera implementations