### PR TITLE
Fix MASK alpha mode rendering issues

### DIFF
--- a/pyrender/mesh.py
+++ b/pyrender/mesh.py
@@ -302,7 +302,7 @@ class Mesh(object):
                         occlusionTexture=mat.occlusionTexture,
                         emissiveTexture=mat.emissiveTexture,
                         emissiveFactor=mat.emissiveFactor,
-                        alphaMode='BLEND',
+                        alphaMode=mat.alphaMode,
                         baseColorFactor=mat.baseColorFactor,
                         baseColorTexture=mat.baseColorTexture,
                         metallicFactor=mat.metallicFactor,

--- a/pyrender/renderer.py
+++ b/pyrender/renderer.py
@@ -564,12 +564,14 @@ class Renderer(object):
                 program.set_uniform(b.format('glossiness_factor'),
                                     material.glossinessFactor)
 
-            # Set blending options
+            # Set alpha options
+            glEnable(GL_BLEND)
             if material.alphaMode == 'BLEND':
-                glEnable(GL_BLEND)
                 glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+            elif material.alphaMode == "MASK":
+                program.set_uniform(b.format('alpha_cutoff'), material.alphaCutoff)
+                glBlendFunc(GL_ONE, GL_ZERO)
             else:
-                glEnable(GL_BLEND)
                 glBlendFunc(GL_ONE, GL_ZERO)
 
             # Set wireframe mode
@@ -988,6 +990,8 @@ class Renderer(object):
                 defines['USE_METALLIC_MATERIAL'] = 1
             elif isinstance(primitive.material, SpecularGlossinessMaterial):
                 defines['USE_GLOSSY_MATERIAL'] = 1
+            if primitive.material.alphaMode == 'MASK':
+                defines['IS_MASK_ALPHA_MODE'] = 1
 
         program = self._program_cache.get_program(
             vertex_shader=vertex_shader,

--- a/pyrender/shaders/mesh.frag
+++ b/pyrender/shaders/mesh.frag
@@ -67,6 +67,9 @@ struct Material {
 #ifdef HAS_BASE_COLOR_TEX
     sampler2D base_color_texture;
 #endif
+#ifdef IS_MASK_ALPHA_MODE
+    float alpha_cutoff;
+#endif
 #ifdef HAS_METALLIC_ROUGHNESS_TEX
     sampler2D metallic_roughness_texture;
 #endif
@@ -337,6 +340,10 @@ void main()
     vec4 base_color = material.base_color_factor;
 #ifdef HAS_BASE_COLOR_TEX
     base_color = base_color * srgb_to_linear(texture(material.base_color_texture, uv_0));
+#endif
+#ifdef IS_MASK_ALPHA_MODE
+    // Discard fragment if alpha is less than the cutoff
+    if (base_color.a <= material.alpha_cutoff) discard;
 #endif
 
     // Compute specular and diffuse colors


### PR DESCRIPTION
I was experiencing issues rendering textures with the `MASK` alpha mode. Some faces would render through the transparent sections and some simply wouldn't. I tracked this down to being caused by the depth buffer treating the transparent sections as opaque.

Here is an example of the depth buffer for a masked texture using the current version of pyrender:
![current](https://user-images.githubusercontent.com/46959407/197345632-779b483d-38fb-4065-8e16-596046e550d7.png)
And the same texture after my changes:
![fixed](https://user-images.githubusercontent.com/46959407/197345797-3441b0d5-b91d-46c5-95e8-3b20359b03b7.png)

I have added a check in `mesh.frag` to discard the fragment if the alpha is less than the material's alpha cutoff. I have also added a new define `IS_MASK_ALPHA_MODE` specifying if the alpha mode is set to `MASK`.

Thank you for taking the time to read, let me know if you have any suggestions!