### PR TITLE
Allow to disable depth mask in forward pass

### DIFF
--- a/pyrender/material.py
+++ b/pyrender/material.py
@@ -109,6 +109,8 @@ class Material(object):
         self.wireframe = wireframe
 
         self._tex_flags = None
+        
+        self.depthMask = True
 
     @property
     def name(self):
@@ -249,6 +251,16 @@ class Material(object):
         material.
         """
         return self._compute_textures()
+    
+    @property
+    def depthMask(self):
+        return self._depthMask
+    
+    @depthMask.setter
+    def depthMask(self, value):
+        if not isinstance(value, bool):
+            raise TypeError('depthMask must be bool')
+        self._depthMask = value
 
     def _compute_transparency(self):
         return False

--- a/pyrender/renderer.py
+++ b/pyrender/renderer.py
@@ -599,6 +599,12 @@ class Renderer(object):
         if primitive.mode == GLTF.POINTS:
             glEnable(GL_PROGRAM_POINT_SIZE)
             glPointSize(self.point_size)
+            
+        # Disable depth mask if specified in material
+        if material.depthMask == False:
+            glDepthMask(GL_FALSE)
+        else:
+            glDepthMask(GL_TRUE)
 
         # Render mesh
         n_instances = 1
@@ -617,6 +623,9 @@ class Renderer(object):
 
         # Unbind mesh buffers
         primitive._unbind()
+        
+        # Depth mask is on by default in forward pass
+        glDepthMask(GL_TRUE)
 
     def _bind_lighting(self, scene, program, node, flags):
         """Bind all lighting uniform values for a scene.


### PR DESCRIPTION
This is the only correct way to draw overlapping transparent objects.