### PR TITLE
Upper bound numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 freetype-py
 imageio
 networkx
-numpy
+numpy<2.0.0
 Pillow
 pyglet==1.4.0a1
 PyOpenGL

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     'freetype-py',                # For font loading
     get_imageio_dep(),            # For Image I/O
     'networkx',                   # For the scene graph
-    'numpy',                      # Numpy
+    'numpy<2.0.0',                # Numpy
     'Pillow',                     # For Trimesh texture conversions
     'pyglet>=1.4.10',             # For the pyglet viewer
     'PyOpenGL~=3.1.0',            # For OpenGL


### PR DESCRIPTION
Fix issue with numpy dependency where version 2.0.0 is not supported #288 