### PR TITLE
Fixed some texture loading errors

### DIFF
--- a/pyrender/material.py
+++ b/pyrender/material.py
@@ -429,6 +429,8 @@ class MetallicRoughnessMaterial(Material):
 
     @baseColorTexture.setter
     def baseColorTexture(self, value):
+        if value and (value.mode == 'LA' or value.mode == "L"):
+            value = value.convert('RGBA')
         self._baseColorTexture = self._format_texture(value, 'RGBA')
         self._tex_flags = None
 

--- a/pyrender/utils.py
+++ b/pyrender/utils.py
@@ -67,6 +67,8 @@ def format_texture_source(texture, target_channels='RGB'):
             texture = np.array(texture * 255.0, dtype=np.uint8)
         elif np.issubdtype(texture.dtype, np.integer):
             texture = texture.astype(np.uint8)
+        elif np.issubdtype(texture.dtype, np.bool_):
+            texture = texture.astype(np.uint8) * 255
         else:
             raise TypeError('Invalid type {} for texture'.format(
                 type(texture)


### PR DESCRIPTION
Small changes to fix texture loading errors that caused crashes when converting some glb models loaded with trimesh to pyrender scenes using `pyrender.Scene.from_trimesh_scene`

- material.py: updated baseColorTexture.setter to check for "L" and "LA" mode textures and convert them to RGBA (avoids ValueError('Cannot reformat 2-channel texture into RGB') for greyscale baseColorTextures 
- utils.py: updated format_texture_source to handle bool textures to aviod TypeError('Invalid type {} for texture'.format(
                type(texture)