### PR TITLE
Relax PyOpenGL version requirement to support OSMesa for offscreen rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     'numpy',                      # Numpy
     'Pillow',                     # For Trimesh texture conversions
     'pyglet>=1.4.10',             # For the pyglet viewer
-    'PyOpenGL~=3.1.0',            # For OpenGL
+    'PyOpenGL>=3.1.0',            # For OpenGL
 #    'PyOpenGL_accelerate~=3.1.0', # For OpenGL
     'scipy',                      # Because of trimesh missing dep
     'six',                        # For Python 2/3 interop


### PR DESCRIPTION
Solves #293. This PR relaxes the PyOpenGL version dependency, enabling compatibility with OSMesa for offscreen rendering. Testing was conducted on Python versions 3.10 through 3.12, across both Ubuntu (22.04 and 24.04) and Fedora, using PyOpenGL 3.1.7.

## Steps to enable OSMesa-based offscreen rendering:

Install OSMesa ang GLU libraries:

### Debian-based distributions (e.g., Ubuntu, Debian):

  ```
  apt-get install libosmesa6-dev libglu1-mesa
  ```
### Red Hat-based distributions (e.g., Fedora, RHEL, CentOS, AlmaLinux, Rocky Linux):

  ```
  dnf -y install mesa-libGL mesa-libOSMesa-devel mesa-libGLU
  ```

Once the appropriate packages are installed, set the environment variable `PYOPENGL_PLATFORM=osmesa` either in your shell or within your Python script:
```python
import os
os.environ["PYOPENGL_PLATFORM"] = "osmesa"
import pyrender
# Your rendering code here
```