### PR TITLE
fix duck model link in example

### DIFF
--- a/examples/duck.py
+++ b/examples/duck.py
@@ -4,8 +4,7 @@ import numpy as np
 import trimesh
 import requests
 
-duck_source = "https://github.com/KhronosGroup/glTF-Sample-Models/raw/master/2.0/Duck/glTF-Binary/Duck.glb"
-
+duck_source = "https://github.com/KhronosGroup/glTF-Sample-Models/raw/refs/heads/main/2.0/Duck/glTF-Binary/Duck.glb"
 duck = trimesh.load(BytesIO(requests.get(duck_source).content), file_type='glb')
 duckmesh = Mesh.from_trimesh(list(duck.geometry.values())[0])
 scene = Scene(ambient_light=np.array([1.0, 1.0, 1.0, 1.0]))


### PR DESCRIPTION
the URL link for the duck model is outdated. fixed it with the new and correct link.