### PR TITLE
Fix issue 288: use np.inf for numpy v2

### DIFF
--- a/pyrender/mesh.py
+++ b/pyrender/mesh.py
@@ -84,8 +84,8 @@ class Mesh(object):
         """(2,3) float : The axis-aligned bounds of the mesh.
         """
         if self._bounds is None:
-            bounds = np.array([[np.infty, np.infty, np.infty],
-                               [-np.infty, -np.infty, -np.infty]])
+            bounds = np.array([[np.inf, np.inf, np.inf],
+                               [-np.inf, -np.inf, -np.inf]])
             for p in self.primitives:
                 bounds[0] = np.minimum(bounds[0], p.bounds[0])
                 bounds[1] = np.maximum(bounds[1], p.bounds[1])


### PR DESCRIPTION
Search and replaced `np.infty` for `np.inf` per error message:
> AttributeError: `np.infty` was removed in the NumPy 2.0 release. Use `np.inf` instead.

The `np.inf` is backward compatible with numpy v1.x.